### PR TITLE
Fix print_vehicle() doesn't have a reference parmeter as stated in the Chapter 3's Exercise .md file

### DIFF
--- a/Chapter03/Exercise/Excercise/AdFunctions.cc
+++ b/Chapter03/Exercise/Excercise/AdFunctions.cc
@@ -4,3 +4,27 @@
 
 #include "AdConstants.h"
 #include "AdFunctions.h"
+
+namespace Add
+{
+namespace Visualize
+{
+
+void print_vehicle(const Ad::Types::VehicleType &vehicle)
+{
+
+}
+
+void print_neighbor_vehicles(const Ad::Types::NeighborVehiclesType &vehicles)
+{
+
+}
+
+void print_scene(const Ad::Types::VehicleType &ego_vehicle,
+                 const Ad::Types::NeighborVehiclesType &vehicles)
+{
+
+}
+
+} // namespace Visualize
+} // namespace Add

--- a/Chapter03/Exercise/Excercise/AdFunctions.h
+++ b/Chapter03/Exercise/Excercise/AdFunctions.h
@@ -23,7 +23,7 @@ Ad::Types::NeighborVehiclesType init_vehicles();
 namespace Visualize
 {
 
-void print_vehicle(const Ad::Types::VehicleType vehicle);
+void print_vehicle(const Ad::Types::VehicleType &vehicle);
 
 void print_neighbor_vehicles(const Ad::Types::NeighborVehiclesType &vehicles);
 


### PR DESCRIPTION
When I was going through Chapter 3's Exercise .md file, I noticed you mentioned in the print_vehicle() function, it would take a reference type, but the code doesn't have it already. Let me know if this is intentional, just a small thing.